### PR TITLE
Fixed issued #1, removed open-foam from slurm-ctrl

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -28,5 +28,3 @@ relations:
     - ganglia-node:node
   - - open-foam:juju-info
     - slurm-node:juju-info
-  - - open-foam:juju-info
-    - slurm-controller:juju-info


### PR DESCRIPTION
Removed relation between open-foam and slurm-controller.